### PR TITLE
Fix for "Error: coordinates must be numbers."

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -101,8 +101,6 @@ class App extends Component {
           updateStartingPoint={updateStartingPoint}
           createDistrict={createDistrict}
           createStartingPoint={createStartingPoint}
-          deleteDistrict={deleteDistrict}
-          deleteStartingPoint={deleteStartingPoint}
           notify={notify}
         />
         <SideDrawer

--- a/src/components/MarketsMap/index.js
+++ b/src/components/MarketsMap/index.js
@@ -383,14 +383,15 @@ class MarketsMap extends Component {
         this.props.createStartingPoint(payload).then((response) => {
           if (response.error) {
             this.map.data.remove(newPolygon)
+          } else {
+            newPolygon.setProperty('id', response.payload.data.id)
+            this.map.data.overrideStyle(newPolygon, {
+              strokeColor: newPolygon.getProperty('color'),
+              strokeWeight: 2,
+              zIndex: 1,
+            })
+            this.setState({ selectedFeature: newPolygon })
           }
-          newPolygon.setProperty('id', response.payload.data.id)
-          this.map.data.overrideStyle(newPolygon, {
-            strokeColor: newPolygon.getProperty('color'),
-            strokeWeight: 2,
-            zIndex: 1,
-          })
-          this.setState({ selectedFeature: newPolygon })
           this.props.handleSaveDone(response)
         })
       }
@@ -499,7 +500,8 @@ class MarketsMap extends Component {
   toPolygons = (multiPolygon) => {
     const polygons = []
     multiPolygon.geometry.coordinates.forEach(coords => {
-      polygons.push({ type: 'Polygon', coordinates: coords })
+      const coordinates = turf.getType(multiPolygon) === 'MultiPolygon' ? coords : [coords]
+      polygons.push({ type: 'Polygon', coordinates })
     })
     return polygons
   }


### PR DESCRIPTION
What was happening:

The overlap algorithm's input is the union of all the regions. The union function will return either a `Polygon` feature or a `MultiPolygon` feature depending on the regions being spatially contiguous. A simple type check was added to handle each format during conversion to an array of `Polygons`. 